### PR TITLE
Update hosty.sh

### DIFF
--- a/hosty.sh
+++ b/hosty.sh
@@ -76,8 +76,8 @@ echo
 echo "Building /etc/hosts..."
 cat $orig > $host
 
-echo "# Don't write below this line. It will be lost if you run hosty again." >> $host
 echo "# Ad blocking hosts generated $(date)" >> $host
+echo "# Don't write below this line. It will be lost if you run hosty again." >> $host
 cat $aux >> $host
 
 ln=$(grep -c "$IP" $host)


### PR DESCRIPTION
La linea "# Ad blocking hosts generated" es la que se usa para saber a partir de donde sobreescribir.
Por eso si haces
echo "# Don't write below this line. It will be lost if you run hosty again." >> $host
echo "# Ad blocking hosts generated $(date)" >> $host
en vez de
echo "# Ad blocking hosts generated $(date)" >> $host
echo "# Don't write below this line. It will be lost if you run hosty again." >> $host

cada vez que se ejecute hosty habra lineas "# Don't write below this line. It will be lost if you run hosty again." duplicadas
Por ejemplo, si ejecutas hosty 3 veces aparecera:

# Don't write below this line. It will be lost if you run hosty again.
# Don't write below this line. It will be lost if you run hosty again.
# Don't write below this line. It will be lost if you run hosty again.
# Ad blocking hosts generated  mar ene 27 21:02:46 CET 2015