### PR TITLE
Update hosty.sh

### DIFF
--- a/hosty.sh
+++ b/hosty.sh
@@ -46,7 +46,7 @@ do
 	if [ $? != 0 ]; then
 		echo "Error downloading $i"
 	else
-		awk '/^[ \t]*(127\.0\.0\.1|0\.0\.0\.0|255\.255\.255\.0)/ {print $2}' $aux >> $host
+		sed -e '/^[[:space:]]*\(127\.0\.0\.1\|0\.0\.0\.0\|255\.255\.255\.0\)[[:space:]]/!d' -e 's/[[:space:]]\+/ /g' $aux | awk '{print $2}' >> $host
 	fi
 done
 # Obtain various AdBlock Plus rules files and merge into one
@@ -68,7 +68,6 @@ fi
 
 echo
 echo "Applying user whitelist, cleaning and de-duplicating..."
-sed -e "/$IP localhost/d" -i $host
 cat /etc/hosts.whitelist > $white
 awk '/^\s*[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/ {print $2}' $orig >> $white
 awk -v ip=$IP 'FNR==NR {arr[$1]++} FNR!=NR {if (!arr[$1]++) print ip, $1}' $white $host > $aux
@@ -94,4 +93,4 @@ echo
 echo "Done, $ln websites blocked."
 echo
 echo "You can always restore your original hosts file with this command:"
-echo "    $ sudo hosty --restore"
+echo "    sudo hosty --restore"


### PR DESCRIPTION
El problema era que el awk no detectaba como espacio alguno de los caracteres que si ve como espacio el sed
Por lo tanto al eliminar duplicados no veia diferencia entre "localhost" y "localhost[espacio raro]"

Con la linea que añadido se quitaran esos espacios. Es mejor hacerlo así que con el sed explicito que tu has puesto para localhost porque eso no arreglaria lo de los duplicados, solo lo del localhost.

En cuanto a la linea
awk '/^\s*[0-9]+.[0-9]+.[0-9]+.[0-9]+/ {print $2}' $orig >> $white
lo que hace es meter en la whitelist temporal todos los dominios que estuvieran en el hosts original (independientemente de si estos iban a 0.0.0.0 o no), ya que si un dominio esta en el hosts original se sobreentiende que no se le quiere redirigir a ningún otro sitio del que ya esta siendo redirigido.