### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Test in Ubuntu/Mac/Alpine
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/astrovm/hosty/security/code-scanning/7](https://github.com/astrovm/hosty/security/code-scanning/7)

To fix the problem, add a `permissions` block at the top level of the workflow file (just after the `name:` and before the `on:` block). This will set the default permissions for all jobs in the workflow to the minimum required, which in this case is `contents: read`. This ensures that the `GITHUB_TOKEN` used by the workflow only has read access to repository contents, reducing the risk of accidental or malicious changes. No changes to the jobs or steps are required, as none of them require additional permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
