### PR TITLE
Remove FreeBSD from CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,28 +149,6 @@ jobs:
             test "$(/usr/local/bin/hosty -v)" = "$(./hosty.sh -v)"
             rm -f /usr/local/bin/hosty /tmp/hosty.sh /tmp/install.sh
 
-  smoke-freebsd:
-    name: Smoke (FreeBSD 15.0)
-    needs: lint
-    if: >
-      github.event_name == 'schedule' ||
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'push' && github.ref == 'refs/heads/main')
-    runs-on: ubuntu-26.04
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Run offline smoke suite in FreeBSD
-        uses: vmactions/freebsd-vm@670398e4236735b8b65805c3da44b7a511fb8b27 # v1.3.0
-        with:
-          release: "15.0"
-          usesh: true
-          prepare: pkg install -y curl expect
-          run: |
-            chmod +x hosty.sh install.sh ci/smoke.sh ci/check-sources.sh ci/expect/*.exp
-            ./ci/smoke.sh
-
   network:
     name: Network full run
     needs: lint

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ![GitHub stars](https://img.shields.io/github/stars/astrovm/hosty.svg?label=Star&style=social)
 ![GitHub forks](https://img.shields.io/github/forks/astrovm/hosty.svg?label=Fork&style=social)](https://github.com/astrovm/hosty)
 
-Hosty is a system-wide hosts-file blocker for Unix-like operating systems. Its scripts use portable POSIX `sh` syntax and common Unix utilities; CI exercises Ubuntu, Alpine/BusyBox, macOS, FreeBSD, and OpenBSD.
+Hosty is a system-wide hosts-file blocker for Unix-like operating systems. Its scripts use portable POSIX `sh` syntax and common Unix utilities; CI exercises Ubuntu, Alpine/BusyBox, macOS, and OpenBSD.
 
 Hosty downloads domain lists, combines them with custom rules, applies a whitelist, and writes the result to `/etc/hosts` without discarding existing entries.
 
@@ -31,15 +31,15 @@ Optional:
 
 Most required utilities are included in the base system. Install missing packages with the platform package manager:
 
-| Platform | Command |
-|---|---|
-| Debian, Ubuntu, Mint, Pop!_OS | `sudo apt install curl mawk cron` |
+| Platform                         | Command                                    |
+| -------------------------------- | ------------------------------------------ |
+| Debian, Ubuntu, Mint, Pop!_OS    | `sudo apt install curl mawk cron`          |
 | Arch Linux, Manjaro, EndeavourOS | `sudo pacman -S --needed curl gawk cronie` |
-| Fedora, RHEL, Rocky Linux | `sudo dnf install curl gawk cronie` |
-| Alpine Linux | `apk add curl` (`cronie` is optional) |
-| macOS | No additional package is normally required |
-| FreeBSD | `pkg install curl` |
-| OpenBSD | `pkg_add curl` |
+| Fedora, RHEL, Rocky Linux        | `sudo dnf install curl gawk cronie`        |
+| Alpine Linux                     | `apk add curl` (`cronie` is optional)      |
+| macOS                            | No additional package is normally required |
+| FreeBSD                          | `pkg install curl`                         |
+| OpenBSD                          | `pkg_add curl`                             |
 
 Run package-manager commands as root. Prefix them with `sudo` or `doas` when configured.
 
@@ -159,7 +159,7 @@ Hosty uses these conventional paths and interfaces:
 - `/usr/local/bin/hosty`
 - the root user's `crontab`
 
-Every pull request runs static POSIX-shell checks plus functional smoke tests on Ubuntu, Alpine Linux with BusyBox `ash`, macOS, and OpenBSD. FreeBSD runs on pushes to `main`, weekly schedules, and manual workflows.
+Every pull request runs static POSIX-shell checks plus functional smoke tests on Ubuntu, Alpine Linux with BusyBox `ash`, macOS, and OpenBSD.
 
 ## Development
 


### PR DESCRIPTION
## Summary
- Remove the `smoke-freebsd` job from the main CI workflow.
- Update README platform/CI docs so they no longer claim FreeBSD is exercised in CI.

FreeBSD remains documented as a supported install target.

## Test plan
- [ ] Confirm CI workflow runs without a FreeBSD job
- [ ] Confirm lint and remaining smoke jobs (Ubuntu, macOS, Alpine, OpenBSD) still pass