### PR TITLE
Update whitelist sources

### DIFF
--- a/lists/whitelist.sources
+++ b/lists/whitelist.sources
@@ -1,7 +1,2 @@
 https://4st.li/hosty/lists/whitelist
-https://raw.githubusercontent.com/anudeepND/whitelist/master/domains/optional-list.txt
-https://raw.githubusercontent.com/anudeepND/whitelist/master/domains/referral-sites.txt
-https://raw.githubusercontent.com/anudeepND/whitelist/master/domains/whitelist.txt
-https://raw.githubusercontent.com/brave/adblock-lists/master/brave-unbreak.txt
-https://raw.githubusercontent.com/raghavdua1995/DNSlock-PiHole-whitelist/master/whitelist.list
-https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/unbreak.txt
+https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/whitelist-referral-onlydomains.txt


### PR DESCRIPTION
## Summary

- remove stale Anudeep and DNSlock whitelist sources
- remove Brave and uBlock Origin browser-filter lists that Hosty cannot parse safely as domain allowlists
- add HaGeZi's maintained, plain-domain referral allowlist

## Why

The previous source set mixed stale domain lists with browser-specific unbreak rules. Hosty's domain extractor loses the browser rules' scope and semantics, potentially turning them into overly broad DNS exceptions. HaGeZi's referral allowlist is actively maintained and directly supports the intended behavior: keeping affiliate, email, search-result, and unsubscribe links working.

## Impact

Hosty retains its curated local exceptions while using one DNS-native remote referral allowlist. This reduces unrelated whitelist entries while preserving redirect-link compatibility.

## Validation

- `git diff --cached --check`
- `HOSTY_CI_LOG_DIR=$(mktemp -d) ./ci/check-sources.sh`
- all 27 configured blacklist and whitelist sources passed the health check