### PR TITLE
Remove Prigent crypto source

### DIFF
--- a/lists/blacklist.sources
+++ b/lists/blacklist.sources
@@ -21,5 +21,4 @@ https://v.firebog.net/hosts/Admiral.txt
 https://v.firebog.net/hosts/Easylist.txt
 https://v.firebog.net/hosts/Easyprivacy.txt
 https://v.firebog.net/hosts/Prigent-Ads.txt
-https://v.firebog.net/hosts/Prigent-Crypto.txt
 https://v.firebog.net/hosts/static/w3kbl.txt


### PR DESCRIPTION
## Summary

Remove Firebog's `Prigent-Crypto.txt` from the default blacklist sources.

## Why

The source is intended to block cryptojacking infrastructure, but it also blocks legitimate cryptocurrency project sites. The compatibility audit confirmed false positives for Bitcoin.org, Dogecoin.com, Zcash, and Kaspa.

## Impact

Legitimate cryptocurrency sites are no longer blocked by this source. The remaining malware, phishing, advertising, and tracking sources are unchanged.

## Validation

- `git diff --check`
- `HOSTY_CI_LOG_DIR=$(mktemp -d) ./ci/check-sources.sh` — all 26 remaining sources passed
- `./hosty.sh -l bitcoin.org dogecoin.com z.cash kaspa.org getmonero.org` — none are blocked