### PR TITLE
Update and simplify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,11 @@
 # hosty
 
-[![GitHub code size](https://img.shields.io/github/languages/code-size/astrovm/hosty.svg)
-![GitHub last commit](https://img.shields.io/github/last-commit/astrovm/hosty.svg)
-![GitHub license](https://img.shields.io/github/license/astrovm/hosty.svg)
-![GitHub watchers](https://img.shields.io/github/watchers/astrovm/hosty.svg?label=Watch&style=social)
-![GitHub stars](https://img.shields.io/github/stars/astrovm/hosty.svg?label=Star&style=social)
-![GitHub forks](https://img.shields.io/github/forks/astrovm/hosty.svg?label=Fork&style=social)](https://github.com/astrovm/hosty)
+[![GitHub last commit](https://img.shields.io/github/last-commit/astrovm/hosty.svg)](https://github.com/astrovm/hosty)
+[![GitHub license](https://img.shields.io/github/license/astrovm/hosty.svg)](https://github.com/astrovm/hosty)
 
 Hosty is a system-wide hosts-file blocker for Unix-like operating systems. Its scripts use portable POSIX `sh` syntax and common Unix utilities; CI exercises Ubuntu, Alpine/BusyBox, macOS, and OpenBSD.
 
-Hosty downloads domain lists, combines them with custom rules, applies a whitelist, and writes the result to `/etc/hosts` without discarding existing entries.
+It downloads domain lists, combines them with custom rules, applies a whitelist, and updates `/etc/hosts` without discarding existing entries.
 
 The default lists focus on ads, tracking, spyware, malware, and other privacy threats. They intentionally avoid political censorship and paternalistic categories such as pornography or gambling.
 
@@ -17,19 +13,12 @@ The default lists focus on ads, tracking, spyware, malware, and other privacy th
 
 ## Requirements
 
-Required:
-
 - a POSIX-compatible `/bin/sh`
-- `curl`
-- `awk`
-- common Unix utilities: `cat`, `chmod`, `cp`, `date`, `dirname`, `grep`, `head`, `id`, `mkdir`, `mktemp`, `mv`, `rm`, and `sort`
+- `curl`, `awk`, and common Unix utilities: `cat`, `chmod`, `cp`, `date`, `dirname`, `grep`, `head`, `id`, `mkdir`, `mktemp`, `mv`, `rm`, `sort`, and `tr`
+- optional: `crontab` for automatic updates
+- optional: `sudo` or `doas` when running Hosty from a non-root account
 
-Optional:
-
-- `crontab`, for automatic updates
-- `sudo` or `doas`, when installing or running Hosty from a non-root account
-
-Most required utilities are included in the base system. Install missing packages with the platform package manager:
+Most required utilities come with the operating system. Install missing packages with the platform package manager:
 
 | Platform                         | Command                                    |
 | -------------------------------- | ------------------------------------------ |
@@ -41,27 +30,17 @@ Most required utilities are included in the base system. Install missing package
 | FreeBSD                          | `pkg install curl`                         |
 | OpenBSD                          | `pkg_add curl`                             |
 
-Run package-manager commands as root. Prefix them with `sudo` or `doas` when configured.
-
 ## Install
 
 ```sh
 curl -fsSL https://4st.li/hosty/install.sh | sh
 ```
 
-The installer:
-
-- runs directly when the current account is root
-- otherwise uses a working `sudo`, falling back to a working `doas`
-- downloads and validates Hosty before replacing an existing installation
-- installs the executable at `/usr/local/bin/hosty`
-- optionally configures automatic updates when `crontab` and a controlling terminal are available
-
-Without a controlling terminal, installation remains non-interactive and skips the automatic-update prompt. Privileged installation must already be allowed without a password. Configure automatic updates later with `hosty --autorun` as root.
+The installer validates Hosty, installs it at `/usr/local/bin/hosty`, and can configure automatic updates. It runs directly as root or uses `sudo`, falling back to `doas`. Without a terminal, it skips the automatic-update prompt.
 
 ## Usage
 
-Hosty must run as root when it changes the system:
+Update the hosts file:
 
 ```sh
 sudo hosty
@@ -69,13 +48,41 @@ sudo hosty
 doas hosty
 ```
 
+Root privileges are required when Hosty changes system files.
+
+Run `hosty --help` for the complete command reference or `hosty --version` for the installed version.
+
+### Inspect lists
+
+Find which lists contain one or more domains:
+
+```sh
+hosty --lookup example.com example.org
+```
+
+Audit which whitelist entries override a blacklist:
+
+```sh
+hosty --check-whitelists
+```
+
+These commands are read-only and do not require root privileges.
+
+Remove inactive whitelist entries and sources:
+
+```sh
+sudo hosty --clean-whitelists
+```
+
+Cleanup changes writable whitelist files. It stops without changing them if blacklist data is incomplete.
+
 ### Automatic updates
 
 ```sh
 sudo hosty --autorun
 ```
 
-Choose `daily`, `weekly`, `monthly`, or `never`. Replace `sudo` with `doas` where appropriate.
+Choose `daily`, `weekly`, `monthly`, or `never`.
 
 ### Debug without changing the system
 
@@ -101,40 +108,29 @@ Restore the hosts file first when you also want to disable the active block list
 
 ## Custom rules
 
-Hosty stores optional configuration under `/etc/hosty`.
+Hosty stores optional configuration under `/etc/hosty`:
 
-### Blacklist
+| File                | Purpose                |
+| ------------------- | ---------------------- |
+| `blacklist`         | domains to block       |
+| `whitelist`         | domains to allow       |
+| `blacklist.sources` | block-list source URLs |
+| `whitelist.sources` | allow-list source URLs |
 
-Add one domain per line to `/etc/hosty/blacklist`:
-
-```text
-facebook.com
-www.facebook.com
-```
-
-### Whitelist
-
-Add one domain per line to `/etc/hosty/whitelist`:
+Add one domain per line to a domain file:
 
 ```text
-4st.li
-www.4st.li
+example.com
+www.example.com
 ```
 
-### Custom sources
-
-Add one URL per line to:
-
-- `/etc/hosty/blacklist.sources` for domains to block
-- `/etc/hosty/whitelist.sources` for domains to allow
-
-Example:
+Add one URL per line to a source file:
 
 ```text
 https://example.com/hosts.txt
 ```
 
-Source files may contain plain domain names or hosts-style entries. Hosty extracts valid-looking domains from uncommented lines. It does not interpret browser filter-list syntax such as ABP, uBlock Origin, or AdGuard rules; use hosts-format versions of those lists instead.
+Sources may contain plain domains or hosts-style entries. Browser filter syntax such as ABP, uBlock Origin, and AdGuard rules is not supported; use hosts-format lists.
 
 Run only with custom sources and local rules:
 
@@ -142,22 +138,9 @@ Run only with custom sources and local rules:
 sudo hosty --ignore-default-sources
 ```
 
-Configure automatic updates in the same mode:
-
-```sh
-sudo hosty --autorun --ignore-default-sources
-```
-
 ## Portability
 
 The scripts avoid Bash-specific syntax and GNU-only text-processing behavior. They use POSIX shell syntax together with `curl`, `mktemp`, and common Unix utilities available on the supported systems.
-
-Hosty uses these conventional paths and interfaces:
-
-- `/etc/hosts`
-- `/etc/hosty`
-- `/usr/local/bin/hosty`
-- the root user's `crontab`
 
 Every pull request runs static POSIX-shell checks plus functional smoke tests on Ubuntu, Alpine Linux with BusyBox `ash`, macOS, and OpenBSD.
 


### PR DESCRIPTION
## Summary

- document the current lookup and whitelist maintenance commands
- correct the required utility list
- simplify installation, usage, and custom-rule guidance
- reduce badge clutter while preserving the memory comparison image

## Why

The README did not cover the list-maintenance commands added to Hosty and omitted a required utility. Several sections were also more repetitive than necessary.

## Impact

Users get a shorter, current guide with clearer command safety and privilege expectations. Runtime behavior is unchanged.

## Checks

- `sh ./hosty.sh --help`
- verified every long CLI option appears in `README.md`
- `git diff --check`